### PR TITLE
Prevent Google Analytics from getting triggered twice

### DIFF
--- a/view/frontend/web/js/google-analytics-mixin.js
+++ b/view/frontend/web/js/google-analytics-mixin.js
@@ -3,15 +3,16 @@ define(['mage/utils/wrapper'], function (wrapper) {
 
     return function (gaFunction) {
         return wrapper.wrap(gaFunction, function (parentMethod, config) {
-            window.addEventListener('CookiebotOnAccept', function () {
-                if (Cookiebot.consent.statistics) {
-                    parentMethod(config);
-                }
-            });
             if (typeof Cookiebot === 'undefined') {
                 return;
             }
-            if (Cookiebot.consent.statistics) {
+            if (!Cookiebot.hasResponse) {
+                window.addEventListener('CookiebotOnAccept', function () {
+                    if (Cookiebot.consent.statistics) {
+                        parentMethod(config);
+                    }
+                });
+            } else if (Cookiebot.consent.statistics) {
                 parentMethod(config);
             }
         })


### PR DESCRIPTION
While using this module I've encountered an issue with GA getting triggered twice long after consenting to statistics cookies - first it got triggered by the "Cookiebot.consent.statistics" check, and shortly after by the CookiebotOnAccept event.

This fix makes it so that the code first checks whether Cookiebot exists, then whether there has been a response by the user, which then adds a listener if there hasn't been one, and if there already has been a response to the consent request, it just checks for whether the statistics consent is given. After making this fix, the issue no longer appeared.