### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "customgento/module-cookiebot-m2",
     "description": "Magento 2 module, which integrates Cookiebot.",
     "type": "magento2-module",
-    "version": "2.1.0",
     "license": "OSL-3.0",
     "authors": [
         {


### PR DESCRIPTION
Remove version from composer.json so packagist can rely on repository tags instead of checked-in version. E.g. 2.1.1 bump forgotten in v2.1.1 tag.