### PR TITLE
Settings widget not available in CSP strict mode

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -12,5 +12,10 @@
                 <value id="cookiebot" type="host">consentcdn.cookiebot.com</value>
             </values>
         </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="cookiebot" type="host">consentcdn.cookiebot.com</value>
+            </values>
+        </policy>
     </policies>
 </csp_whitelist>


### PR DESCRIPTION
When setting `csp/mode/storefront/report_only` to "0", then an error message appears in console and the settings icon is unavailable.

![CSP console error](https://user-images.githubusercontent.com/1771622/206443641-e9866d25-9ad2-4a7a-9da6-6bc80338614b.png)

The PR adds the missing CSP entry, cookie settings can then be updated.

![pr_settings_icon](https://user-images.githubusercontent.com/1771622/206443353-70316eca-2542-4ed8-87b1-302f4bfbe5ad.png)
