### PR TITLE
Adding CSP support to the inline google consent mode script, while ke…

### DIFF
--- a/view/frontend/templates/script.phtml
+++ b/view/frontend/templates/script.phtml
@@ -1,12 +1,19 @@
-<?php /** @var Magento\Framework\View\Element\Template $block */ ?>
-<?php /** @var CustomGento\Cookiebot\ViewModel\Script $viewModel */ ?>
-<?php $viewModel = $block->getData('view_model') ?>
-<?= /* @noEscape */ $viewModel->getScript() ?>
-
 <?php
-if ($viewModel->isGoogleConsentModeEnabled()):
-    ?>
-    <script data-cookieconsent="ignore">
+    use CustomGento\Cookiebot\ViewModel\Script as CookiebotScriptViewModel;
+    use Magento\Framework\View\Element\Template;
+    use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+    /** @var CookiebotScriptViewModel $viewModel */
+    /** @var SecureHtmlRenderer $secureRenderer */
+    /** @var Template $block */
+
+    $viewModel = $block->getData('view_model')
+?>
+<?= /* @noEscape */ $viewModel->getScript() ?>
+<?php
+
+if ($viewModel->isGoogleConsentModeEnabled()) {
+    $scriptString = '
         window.dataLayer = window.dataLayer || [];
 
         function gtag() {
@@ -25,5 +32,12 @@ if ($viewModel->isGoogleConsentModeEnabled()):
         });
         gtag("set", "ads_data_redaction", true);
         gtag("set", "url_passthrough", true);
-    </script>
-<?php endif; ?>
+    ';
+
+    // checking on if SecureHtmlRenderer exists first, because this module is still compatible with Magento 2.3.x which doesn't include this class
+    if (class_exists(SecureHtmlRenderer::class)) {
+        echo $secureRenderer->renderTag('script', ['data-cookieconsent' => 'ignore'], $scriptString, false);
+    } else {
+        echo '<script data-cookieconsent="ignore">' . $scriptString . '<script>';
+    }
+}


### PR DESCRIPTION
…eping in mind compatibility with Magento 2.3.x and 2.4.x

I noticed while installing this module in a Magento 2.4.7-p4 shop that we got an error on the checkout in the browser console that this inline google consent mode script is being blocked by the Content-Security-Policy checks in the browser.
We need to add a `nonce` to the script to allow CSP checks to not block this script.

I've created this PR to fix that.

Good to know:
- The `SecureHtmlRenderer` class doesn't exist in Magento 2.3.x, and your `composer.json` indicates that this module can still be installed on Magento 2.3.x shops, so I'm first checking if that class exists before trying to use it. Otherwise I'm just outputting the script as-is. [Read more about it here](https://github.com/yireo/Yireo_GoogleTagManager2/pull/231#issuecomment-2055470093)
- I'm explicitly not using heredoc syntax for putting the script into a string, because of a known bug with html minification in older version of Magento that can't work with it. [Read more about it here](https://github.com/yireo/Yireo_GoogleTagManager2/pull/231#issuecomment-2114295757)

I also cleaned up some code styling/formatting, let me know if this doesn't follow the standards used in this module and if it should be reworked in some way.