### PR TITLE
Declared as compatible with PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "magento/framework": "~102.0||~103.0",
         "magento/module-catalog": "~103.0||~104.0",
         "magento/module-cms": "~103.0||~104.0",
-        "php": "~7.4.0||~8.1.0||~8.2.0||~8.3.0"
+        "php": "~7.4.0||~8.1.0||~8.2.0||~8.3.0||~8.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.5||~9.5",


### PR DESCRIPTION
Hi!

I quickly tested this module with the standard php linter and the phpcompatibility tool and none found problems with PHP 8.4 compatibility:

```
$ find . -type f -iname '*.phtml' ! -path './vendor/*' -exec php84 -l {} +
No syntax errors detected in ./view/frontend/templates/script.phtml

$ find . -type f -iname '*.php' ! -path './vendor/*' -exec php84 -l {} +
No syntax errors detected in ./Test/Integration/AddScriptTest.php
No syntax errors detected in ./Test/Integration/Model/ConfigTest.php
No syntax errors detected in ./Test/Integration/Model/ScriptGeneratorTest.php
No syntax errors detected in ./ViewModel/Script.php
No syntax errors detected in ./registration.php
No syntax errors detected in ./Model/Config.php
No syntax errors detected in ./Model/ScriptGenerator.php

$ phpcs --standard=PHPCompatibility --runtime-set testVersion 8.4 .
```