### PR TITLE
Center and Capitalize, DEV-1491

### DIFF
--- a/view/frontend/templates/iframe-handler.phtml
+++ b/view/frontend/templates/iframe-handler.phtml
@@ -49,9 +49,10 @@ $scriptString = '
                 divElement.classList.add(`cookieconsent-optout-${consentType}`);
                 const consentMessage = `' . $escaper->escapeJs($consentMessage) . '`;
                 const message = consentMessage
-                    .replace("%1", consentType)
+                    .replace("%1", consentType.charAt(0).toUpperCase() + consentType.slice(1))
                     .replace("%2", serviceProvider);
                 paragraphElement.innerHTML = message;
+                paragraphElement.style.textAlign = "center";
 
                 divElement.style.fontSize = "1.4rem";
                 divElement.append(paragraphElement);


### PR DESCRIPTION
Centered the hint and capitalized the consent type. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Capitalizes the consent type in the iframe consent message and centers the hint text.
> 
> - **Frontend (Magento template)**:
>   - In `view/frontend/templates/iframe-handler.phtml`:
>     - Capitalizes the consent type in the consent message (`consentType.charAt(0).toUpperCase() + consentType.slice(1)`).
>     - Centers the consent/hint text via `paragraphElement.style.textAlign = "center"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 556277a11c40e47335e9a40e3a44bc43c2534ef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->