### PR TITLE
Fix video element, DEV-1536

### DIFF
--- a/view/frontend/web/js/slide-widget-mixin.js
+++ b/view/frontend/web/js/slide-widget-mixin.js
@@ -25,13 +25,19 @@ define([
 
         return function (config, element) {
             const videoElement = element[0].querySelector('[data-background-type=video]');
+
+            if (!videoElement) {
+                originalWidget(config, element);
+                return;
+            }
+
             const blockVideoConsentConfig = window.cookiebotConfig && window.cookiebotConfig.blockVideosUntilConsent;
             const videoSrc = videoElement.getAttribute('data-video-src');
             const cookieblockSrc = videoElement.getAttribute('data-cookieblock-src');
             const src = videoSrc || cookieblockSrc;
             let previousStatus = '';
             
-            if (!videoElement || !blockVideoConsentConfig || !isSupportedVideoPlatform(src)) {
+            if (!blockVideoConsentConfig || !isSupportedVideoPlatform(src)) {
                 originalWidget(config, element);
                 return;
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the slide widget mixin safely handles slides without a video background while preserving Cookiebot-based blocking for supported platforms.
> 
> - Adds an early return when no `videoElement` is found, invoking `originalWidget` to avoid running video/consent logic
> - Adjusts guard to only check `blockVideoConsentConfig` and `isSupportedVideoPlatform(src)` (removes `!videoElement` from the combined condition)
> - Affects `view/frontend/web/js/slide-widget-mixin.js` behavior for video backgrounds and consent blocking
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77358f58f3cdf58820014ea14bc348ec315e4155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->