### PR TITLE
Fix js error, DEV-1536

### DIFF
--- a/view/frontend/web/js/fotorama-video-events-mixin.js
+++ b/view/frontend/web/js/fotorama-video-events-mixin.js
@@ -22,6 +22,11 @@ define([
                 addEventListener('CookiebotOnAccept', () => {
                     if (Cookiebot?.consent?.marketing) {
                         const cookiebotOutput = document?.querySelector('.cookieconsent-optout-marketing');
+
+                        if (!cookiebotOutput) {
+                            return;
+                        }
+
                         const videoElement = cookiebotOutput.closest('.video-unplayed[aria-hidden="false"]');
 
                         const event = new PointerEvent('click', {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents a runtime error in `fotorama-video-events-mixin.js` when handling `CookiebotOnAccept`.
> 
> - Adds a guard to ensure `document.querySelector('.cookieconsent-optout-marketing')` exists before finding the video element and dispatching a click event
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55d022016ae9acee947de83e59bf44fbd1eebad2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->