### PR TITLE
Fix csp errrors, DEV-1113

### DIFF
--- a/Model/ScriptGenerator.php
+++ b/Model/ScriptGenerator.php
@@ -14,14 +14,12 @@ class ScriptGenerator
             src="https://consent.cookiebot.com/uc.js"
             data-cbid="%s"
             %s
-            %s
             type="text/javascript" async></script>';
     private const EU_COOKIEBOT_SCRIPT_FORMAT = '<script
             id="Cookiebot"
             data-cfasync="false"
             src="https://consent.cookiebot.eu/uc.js"
             data-cbid="%s"
-            %s
             %s
             type="text/javascript" async></script>';
 
@@ -36,12 +34,11 @@ class ScriptGenerator
         $cookiebotId = $this->config->getId();
         $dataCulture = $this->config->getDataCulture() ?
             sprintf('data-culture="%s"', $this->config->getDataCulture()) : '';
-        $nonce       = sprintf('nonce="%s"', $this->cspNonceProvider->generateNonce());
 
         if ($this->config->useEuCdn()) {
-            return sprintf(self::EU_COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture, $nonce);
+            return sprintf(self::EU_COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture);
         }
 
-        return sprintf(self::COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture, $nonce);
+        return sprintf(self::COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture);
     }
 }

--- a/Model/ScriptGenerator.php
+++ b/Model/ScriptGenerator.php
@@ -14,12 +14,14 @@ class ScriptGenerator
             src="https://consent.cookiebot.com/uc.js"
             data-cbid="%s"
             %s
+            %s
             type="text/javascript" async></script>';
     private const EU_COOKIEBOT_SCRIPT_FORMAT = '<script
             id="Cookiebot"
             data-cfasync="false"
             src="https://consent.cookiebot.eu/uc.js"
             data-cbid="%s"
+            %s
             %s
             type="text/javascript" async></script>';
 
@@ -34,11 +36,12 @@ class ScriptGenerator
         $cookiebotId = $this->config->getId();
         $dataCulture = $this->config->getDataCulture() ?
             sprintf('data-culture="%s"', $this->config->getDataCulture()) : '';
+        $nonce       = sprintf('nonce="%s"', $this->cspNonceProvider->generateNonce());
 
         if ($this->config->useEuCdn()) {
-            return sprintf(self::EU_COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture);
+            return sprintf(self::EU_COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture, $nonce);
         }
 
-        return sprintf(self::COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture);
+        return sprintf(self::COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture, $nonce);
     }
 }

--- a/Model/ScriptGenerator.php
+++ b/Model/ScriptGenerator.php
@@ -21,9 +21,14 @@ class ScriptGenerator
             %s
             type="text/javascript" async></script>';
 
-    public function __construct(
-        private readonly Config $config
-    ) {
+    /**
+     * @var Config
+     */
+    private $config;
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
     }
 
     public function generate(): string

--- a/Model/ScriptGenerator.php
+++ b/Model/ScriptGenerator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CustomGento\Cookiebot\Model;
 
-use Magento\Csp\Helper\CspNonceProvider;
-
 class ScriptGenerator
 {
     private const COOKIEBOT_SCRIPT_FORMAT = '<script
@@ -14,7 +12,6 @@ class ScriptGenerator
             src="https://consent.cookiebot.com/uc.js"
             data-cbid="%s"
             %s
-            %s
             type="text/javascript" async></script>';
     private const EU_COOKIEBOT_SCRIPT_FORMAT = '<script
             id="Cookiebot"
@@ -22,12 +19,10 @@ class ScriptGenerator
             src="https://consent.cookiebot.eu/uc.js"
             data-cbid="%s"
             %s
-            %s
             type="text/javascript" async></script>';
 
     public function __construct(
-        private readonly Config $config,
-        private readonly CspNonceProvider $cspNonceProvider
+        private readonly Config $config
     ) {
     }
 
@@ -36,12 +31,11 @@ class ScriptGenerator
         $cookiebotId = $this->config->getId();
         $dataCulture = $this->config->getDataCulture() ?
             sprintf('data-culture="%s"', $this->config->getDataCulture()) : '';
-        $nonce       = sprintf('nonce="%s"', $this->cspNonceProvider->generateNonce());
 
         if ($this->config->useEuCdn()) {
-            return sprintf(self::EU_COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture, $nonce);
+            return sprintf(self::EU_COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture);
         }
 
-        return sprintf(self::COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture, $nonce);
+        return sprintf(self::COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture);
     }
 }

--- a/Model/ScriptGenerator.php
+++ b/Model/ScriptGenerator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CustomGento\Cookiebot\Model;
 
+use Magento\Csp\Helper\CspNonceProvider;
+
 class ScriptGenerator
 {
     private const COOKIEBOT_SCRIPT_FORMAT = '<script
@@ -12,6 +14,7 @@ class ScriptGenerator
             src="https://consent.cookiebot.com/uc.js"
             data-cbid="%s"
             %s
+            %s
             type="text/javascript" async></script>';
     private const EU_COOKIEBOT_SCRIPT_FORMAT = '<script
             id="Cookiebot"
@@ -19,16 +22,13 @@ class ScriptGenerator
             src="https://consent.cookiebot.eu/uc.js"
             data-cbid="%s"
             %s
+            %s
             type="text/javascript" async></script>';
 
-    /**
-     * @var Config
-     */
-    private $config;
-
-    public function __construct(Config $config)
-    {
-        $this->config = $config;
+    public function __construct(
+        private readonly Config $config,
+        private readonly CspNonceProvider $cspNonceProvider
+    ) {
     }
 
     public function generate(): string
@@ -36,11 +36,12 @@ class ScriptGenerator
         $cookiebotId = $this->config->getId();
         $dataCulture = $this->config->getDataCulture() ?
             sprintf('data-culture="%s"', $this->config->getDataCulture()) : '';
+        $nonce       = sprintf('nonce="%s"', $this->cspNonceProvider->generateNonce());
 
         if ($this->config->useEuCdn()) {
-            return sprintf(self::EU_COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture);
+            return sprintf(self::EU_COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture, $nonce);
         }
 
-        return sprintf(self::COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture);
+        return sprintf(self::COOKIEBOT_SCRIPT_FORMAT, $cookiebotId, $dataCulture, $nonce);
     }
 }

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -8,8 +8,6 @@
                 <value id="cookiebot_cdn" type="host">consentcdn.cookiebot.com</value>
                 <value id="cookiebot_eu" type="host">consent.cookiebot.eu</value>
                 <value id="cookiebot_cdn_eu" type="host">consentcdn.cookiebot.eu</value>
-                <!-- Hash for Cookiebot inline script (nonce not fully supported by uc.js) -->
-                <value id="cookiebot_inline" type="hash" algorithm="sha256">izGUmFn9PZE6G7QuIdXAy77nhcrcwBISVZL+PdWAZFA=</value>
             </values>
         </policy>
         <policy id="frame-src">

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -5,7 +5,11 @@
         <policy id="script-src">
             <values>
                 <value id="cookiebot" type="host">consent.cookiebot.com</value>
+                <value id="cookiebot_cdn" type="host">consentcdn.cookiebot.com</value>
                 <value id="cookiebot_eu" type="host">consent.cookiebot.eu</value>
+                <value id="cookiebot_cdn_eu" type="host">consentcdn.cookiebot.eu</value>
+                <!-- Hash for Cookiebot inline script (nonce not fully supported by uc.js) -->
+                <value id="cookiebot_inline" type="hash" algorithm="sha256">izGUmFn9PZE6G7QuIdXAy77nhcrcwBISVZL+PdWAZFA=</value>
             </values>
         </policy>
         <policy id="frame-src">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds missing Cookiebot domains to CSP to prevent blocking of consent functionality.
> 
> - `script-src`: adds `consentcdn.cookiebot.com` and `consentcdn.cookiebot.eu`
> - `frame-src`: allows `consentcdn.cookiebot.com` and `consentcdn.cookiebot.eu`
> - `connect-src`: allows `consentcdn.cookiebot.com`, `consentcdn.cookiebot.eu`, `consent.cookiebot.com`, `consent.cookiebot.eu`
> - `img-src`: allows `imgsct.cookiebot.com` and `imgsct.cookiebot.eu`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1482b03d85112f6924b19deaabc6d6a17de60a01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->