### PR TITLE
Improve video blocker, DEV-1618

### DIFF
--- a/Model/ExternalVideoReplacer.php
+++ b/Model/ExternalVideoReplacer.php
@@ -8,6 +8,14 @@ class ExternalVideoReplacer
 {
     public function replaceIframeSources(string $content): string
     {
+        $content = $this->replaceIframeTags($content);
+        $content = $this->replaceVideoBackgroundAttributes($content);
+
+        return $content;
+    }
+
+    private function replaceIframeTags(string $content): string
+    {
         $iframePatterns = [
             // YouTube patterns
             '/<iframe([^>]*)\s+src=["\'](https?:\/\/(?:www\.)?(?:youtube\.com|youtube-nocookie\.com)\/embed\/[^"\']+)["\']([^>]*)>/i',
@@ -31,6 +39,37 @@ class ExternalVideoReplacer
 
                 return '<iframe' . $beforeSrc . ' data-cookieblock-src="' . $iframeUrl
                     . '" data-cookieconsent="marketing"' . $afterSrc . '>';
+            }, $content);
+        }
+
+        return $content;
+    }
+
+    private function replaceVideoBackgroundAttributes(string $content): string
+    {
+        // Pattern to match elements with data-video-src attribute containing YouTube or Vimeo URLs
+        $videoBackgroundPatterns = [
+            // YouTube patterns in data-video-src
+            '/(<[^>]+)data-video-src=["\'](https?:\/\/(?:www\.)?(?:youtube\.com|youtube-nocookie\.com)\/embed\/[^"\']+)["\']([^>]*>)/i',
+            '/(<[^>]+)data-video-src=["\'](https?:\/\/(?:www\.)?youtu\.be\/[^"\']+)["\']([^>]*>)/i',
+            // Vimeo patterns in data-video-src
+            '/(<[^>]+)data-video-src=["\'](https?:\/\/(?:www\.)?vimeo\.com\/[^"\']+)["\']([^>]*>)/i',
+            '/(<[^>]+)data-video-src=["\'](https?:\/\/(?:www\.)?player\.vimeo\.com\/[^"\']+)["\']([^>]*>)/i'
+        ];
+
+        foreach ($videoBackgroundPatterns as $pattern) {
+            $content = preg_replace_callback($pattern, function (array $matches) {
+                $beforeAttr = $matches[1];
+                $videoUrl   = $matches[2];
+                $afterAttr  = $matches[3];
+
+                // Check if data-cookieconsent already exists
+                if (preg_match('/data-cookieconsent=["\'][^"\']*["\']/', $beforeAttr . $afterAttr)) {
+                    return $beforeAttr . 'data-cookieblock-src="' . $videoUrl . '"' . $afterAttr;
+                }
+
+                return $beforeAttr . 'data-cookieblock-src="' . $videoUrl
+                    . '" data-cookieconsent="marketing"' . $afterAttr;
             }, $content);
         }
 

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -4,12 +4,15 @@ var config = {
             'Magento_GoogleAnalytics/js/google-analytics': {
                 'CustomGento_Cookiebot/js/google-analytics-mixin': true
             },
-            'Magento_ProductVideo/js/fotorama-add-video-events': {
-                'CustomGento_Cookiebot/js/fotorama-video-events-mixin': true
+            'Magento_PageBuilder/js/widget/video-background': {
+                'CustomGento_Cookiebot/js/video-background-mixin': true
             },
             'Magento_PageBuilder/js/content-type/slide/appearance/default/widget': {
                 'CustomGento_Cookiebot/js/slide-widget-mixin': true
             },
+            'Magento_ProductVideo/js/fotorama-add-video-events': {
+                'CustomGento_Cookiebot/js/fotorama-video-events-mixin': true
+            }
         }
     }
 };

--- a/view/frontend/web/js/slide-widget-mixin.js
+++ b/view/frontend/web/js/slide-widget-mixin.js
@@ -1,28 +1,14 @@
 define([
     'jquery',
     'underscore',
+    'CustomGento_Cookiebot/js/video-blocker-widget',
+    'CustomGento_Cookiebot/js/video-platform-validator',
     'Magento_PageBuilder/js/widget/show-on-hover',
-    'Magento_PageBuilder/js/widget/video-background',
-    'CustomGento_Cookiebot/js/video-blocker-widget'
-], function ($, _, showOnHover, videoBackground, createVideoBlocker) {
+    'Magento_PageBuilder/js/widget/video-background'
+], function ($, _, createVideoBlocker, isSupportedVideoPlatform, showOnHover, videoBackground) {
     'use strict';
 
     return function (originalWidget) {
-        function isSupportedVideoPlatform(url) {
-            if (!url) {
-                return false;
-            }
-            
-            // Regex patterns for supported video platforms
-            const youtubePattern = /^https?:\/\/(www\.)?(youtube\.com|youtu\.be)\//i;
-            const youtubeNocookiePattern = /^https?:\/\/(www\.)?youtube-nocookie\.com\//i;
-            const vimeoPattern = /^https?:\/\/(www\.)?(vimeo\.com|player\.vimeo\.com)\//i;
-            
-            return youtubePattern.test(url) || 
-                   youtubeNocookiePattern.test(url) || 
-                   vimeoPattern.test(url);
-        }
-
         return function (config, element) {
             const videoElement = element[0].querySelector('[data-background-type=video]');
 

--- a/view/frontend/web/js/video-background-mixin.js
+++ b/view/frontend/web/js/video-background-mixin.js
@@ -1,0 +1,85 @@
+define([
+    'jquery',
+    'CustomGento_Cookiebot/js/video-blocker-widget'
+], function ($, createVideoBlocker) {
+    'use strict';
+
+    return function (originalWidget) {
+        function isSupportedVideoPlatform(url) {
+            if (!url) {
+                return false;
+            }
+
+            var youtubePattern = /^https?:\/\/(www\.)?(youtube\.com|youtu\.be)\//i;
+            var youtubeNocookiePattern = /^https?:\/\/(www\.)?youtube-nocookie\.com\//i;
+            var vimeoPattern = /^https?:\/\/(www\.)?(vimeo\.com|player\.vimeo\.com)\//i;
+
+            return youtubePattern.test(url) ||
+                youtubeNocookiePattern.test(url) ||
+                vimeoPattern.test(url);
+        }
+
+        return function (config, element) {
+            const $element = $(element);
+            const videoElement = $element[0];
+            const ElementStyles = window.getComputedStyle(element);
+            const height = ElementStyles.minHeight || '300px';
+            const width = ElementStyles.width || '400px';
+
+            if ($element.data('background-type') !== 'video') {
+                originalWidget(config, element);
+                return;
+            }
+
+            var blockVideoConsentConfig = window.cookiebotConfig && window.cookiebotConfig.blockVideosUntilConsent;
+            var videoSrc = videoElement.getAttribute('data-video-src');
+            var cookieblockSrc = videoElement.getAttribute('data-cookieblock-src');
+            var src = videoSrc || cookieblockSrc;
+            var previousStatus = '';
+            var blockerElement = null;
+
+            if (!blockVideoConsentConfig || !isSupportedVideoPlatform(src)) {
+                originalWidget(config, element);
+                return;
+            }
+
+            addEventListener('CookiebotOnLoad', videoBackgroundBlocker);
+
+            function videoBackgroundBlocker() {
+                if (previousStatus === 'blocked' && (!window.Cookiebot?.consent?.marketing)) {
+                    return;
+                }
+
+                if (!window.Cookiebot?.consent?.marketing) {
+                    if (videoSrc) {
+                        videoElement.setAttribute('data-cookieblock-src', videoSrc);
+                        videoElement.removeAttribute('data-video-src');
+                    }
+                    videoElement.style.display = 'none';
+                    blockerElement = createVideoBlocker(videoElement);
+                    const blockerElementContent = blockerElement.querySelector('div');
+                    blockerElementContent.style.height = height;
+                    blockerElementContent.style.width = width;
+                    previousStatus = 'blocked';
+                    return;
+                }
+
+                if (!videoElement.getAttribute('data-video-src') && cookieblockSrc) {
+                    videoElement.setAttribute('data-video-src', cookieblockSrc);
+                    videoElement.removeAttribute('data-cookieblock-src');
+                }
+                videoElement.style.display = 'block';
+
+                if (blockerElement) {
+                    blockerElement.remove();
+                    blockerElement = null;
+                }
+
+                originalWidget(config, element);
+                previousStatus = 'unblocked';
+            }
+
+            videoBackgroundBlocker();
+        };
+    };
+});

--- a/view/frontend/web/js/video-background-mixin.js
+++ b/view/frontend/web/js/video-background-mixin.js
@@ -19,12 +19,19 @@ define([
                 vimeoPattern.test(url);
         }
 
+        function getValidDimension(value, fallback) {
+            if (!value || parseFloat(value) === 0) {
+                return fallback;
+            }
+            return value;
+        }
+
         return function (config, element) {
             const videoElementContainer = $(element);
             const videoElement = videoElementContainer[0];
             const videoElementStyles = window.getComputedStyle(element);
-            const height = videoElementStyles.minHeight || '300px';
-            const width = videoElementStyles.width || '400px';
+            const height = getValidDimension(videoElementStyles.minHeight, '300px');
+            const width = getValidDimension(videoElementStyles.width, '400px');
 
             if (videoElementContainer.data('background-type') !== 'video') {
                 originalWidget(config, element);

--- a/view/frontend/web/js/video-background-mixin.js
+++ b/view/frontend/web/js/video-background-mixin.js
@@ -20,13 +20,13 @@ define([
         }
 
         return function (config, element) {
-            const $element = $(element);
-            const videoElement = $element[0];
-            const ElementStyles = window.getComputedStyle(element);
-            const height = ElementStyles.minHeight || '300px';
-            const width = ElementStyles.width || '400px';
+            const videoElementContainer = $(element);
+            const videoElement = videoElementContainer[0];
+            const videoElementStyles = window.getComputedStyle(element);
+            const height = videoElementStyles.minHeight || '300px';
+            const width = videoElementStyles.width || '400px';
 
-            if ($element.data('background-type') !== 'video') {
+            if (videoElementContainer.data('background-type') !== 'video') {
                 originalWidget(config, element);
                 return;
             }

--- a/view/frontend/web/js/video-background-mixin.js
+++ b/view/frontend/web/js/video-background-mixin.js
@@ -1,24 +1,11 @@
 define([
     'jquery',
-    'CustomGento_Cookiebot/js/video-blocker-widget'
-], function ($, createVideoBlocker) {
+    'CustomGento_Cookiebot/js/video-blocker-widget',
+    'CustomGento_Cookiebot/js/video-platform-validator'
+], function ($, createVideoBlocker, isSupportedVideoPlatform) {
     'use strict';
 
     return function (originalWidget) {
-        function isSupportedVideoPlatform(url) {
-            if (!url) {
-                return false;
-            }
-
-            var youtubePattern = /^https?:\/\/(www\.)?(youtube\.com|youtu\.be)\//i;
-            var youtubeNocookiePattern = /^https?:\/\/(www\.)?youtube-nocookie\.com\//i;
-            var vimeoPattern = /^https?:\/\/(www\.)?(vimeo\.com|player\.vimeo\.com)\//i;
-
-            return youtubePattern.test(url) ||
-                youtubeNocookiePattern.test(url) ||
-                vimeoPattern.test(url);
-        }
-
         function getValidDimension(value, fallback) {
             if (!value || parseFloat(value) === 0) {
                 return fallback;
@@ -38,12 +25,12 @@ define([
                 return;
             }
 
-            var blockVideoConsentConfig = window.cookiebotConfig && window.cookiebotConfig.blockVideosUntilConsent;
-            var videoSrc = videoElement.getAttribute('data-video-src');
-            var cookieblockSrc = videoElement.getAttribute('data-cookieblock-src');
-            var src = videoSrc || cookieblockSrc;
-            var previousStatus = '';
-            var blockerElement = null;
+            const blockVideoConsentConfig = window.cookiebotConfig && window.cookiebotConfig.blockVideosUntilConsent;
+            const videoSrc = videoElement.getAttribute('data-video-src');
+            const cookieblockSrc = videoElement.getAttribute('data-cookieblock-src');
+            const src = videoSrc || cookieblockSrc;
+            let previousStatus = '';
+            let blockerElement = null;
 
             if (!blockVideoConsentConfig || !isSupportedVideoPlatform(src)) {
                 originalWidget(config, element);

--- a/view/frontend/web/js/video-platform-validator.js
+++ b/view/frontend/web/js/video-platform-validator.js
@@ -1,0 +1,17 @@
+define([], function () {
+    'use strict';
+
+    return function isSupportedVideoPlatform(url) {
+        if (!url) {
+            return false;
+        }
+
+        const youtubePattern = /^https?:\/\/(www\.)?(youtube\.com|youtu\.be)\//i;
+        const youtubeNocookiePattern = /^https?:\/\/(www\.)?youtube-nocookie\.com\//i;
+        const vimeoPattern = /^https?:\/\/(www\.)?(vimeo\.com|player\.vimeo\.com)\//i;
+
+        return youtubePattern.test(url) ||
+            youtubeNocookiePattern.test(url) ||
+            vimeoPattern.test(url);
+    };
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches both server-side HTML rewriting and PageBuilder widget initialization, so regressions could break video background rendering or leave videos blocked/unblocked incorrectly depending on consent state.
> 
> **Overview**
> Extends the video consent blocker beyond iframes to also handle PageBuilder *video backgrounds*: `ExternalVideoReplacer` now rewrites `data-video-src` attributes for YouTube/Vimeo URLs into `data-cookieblock-src` (and adds `data-cookieconsent="marketing"` when missing).
> 
> On the frontend, adds a new RequireJS mixin for `Magento_PageBuilder/js/widget/video-background` that swaps `data-video-src`/`data-cookieblock-src`, hides the element, and injects/removes the blocker overlay until marketing consent is granted; the slide widget mixin is adjusted to reuse a shared `video-platform-validator` helper instead of duplicating URL checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f96e01259fd1b9fbe1cd2f288cac43efd474108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->